### PR TITLE
Fix startup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "type": "module",
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "ts-node gasguardian-userbot.ts",
     "build": "tsc",
     "prisma": "prisma"
   },


### PR DESCRIPTION
## Summary
- correct start command to run the main bot script

## Testing
- `npm run build`
- `npm run start` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3dbd8978832ca6102b2e85d5296c