### PR TITLE
Add Jest and relevance tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,11 @@
         "telegram": "^2.26.22",
         "tsx": "^4.19.4"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
+        "@types/jest": "^29.5.3"
+      }
     },
     "node_modules/@cryptography/aes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "ts-node gasguardian-userbot.ts",
     "build": "tsc",
-    "prisma": "prisma"
+    "prisma": "prisma",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
@@ -21,6 +22,9 @@
   "devDependencies": {
     "typescript": "^5.4.5",
     "ts-node": "^10.9.2",
-    "prisma": "^6.8.2"
+    "prisma": "^6.8.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/relevance.ts
+++ b/relevance.ts
@@ -1,0 +1,58 @@
+export const RELEVANT_KEYWORDS = [
+  // English
+  "gas",
+  "ethereum",
+  "eth",
+  "polygon",
+  "gas fees",
+  "defi",
+  "transaction",
+  "fee",
+  "arbitrum",
+  "optimism",
+  "l2",
+  "zksync",
+  "starknet",
+  "gas optimization",
+  "eth gas tracker",
+  "cheap gas",
+  "gas price",
+  "gas monitor",
+  "gas analyzer",
+  // Russian
+  "газ",
+  "газовые комиссии",
+  "газ эфириум",
+  "экономия газа",
+  "низкие комиссии",
+  "дефи",
+  "эфириум",
+  "газ трекер",
+  "газ прайс",
+  "дешевый газ",
+  "газ монитор",
+  "алгоритм оптимизации",
+];
+
+export function containsRelevantKeyword(messages: string[]): boolean {
+  const lowerMsgs = messages.map((t) => t.toLowerCase());
+  for (const msg of lowerMsgs) {
+    for (const kw of RELEVANT_KEYWORDS) {
+      if (msg.includes(kw.toLowerCase())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function pickMostRelevantMessage(messages: string[]): string | null {
+  for (const text of messages) {
+    for (const kw of RELEVANT_KEYWORDS) {
+      if (text.toLowerCase().includes(kw.toLowerCase())) {
+        return text;
+      }
+    }
+  }
+  return null;
+}

--- a/tests/relevance.test.ts
+++ b/tests/relevance.test.ts
@@ -1,0 +1,30 @@
+import { containsRelevantKeyword, pickMostRelevantMessage } from '../relevance';
+
+describe('containsRelevantKeyword', () => {
+  test('returns true when any message contains a keyword', () => {
+    const msgs = ['hello', 'cheap gas here'];
+    expect(containsRelevantKeyword(msgs)).toBe(true);
+  });
+
+  test('returns false when no messages contain keywords', () => {
+    const msgs = ['hello', 'world'];
+    expect(containsRelevantKeyword(msgs)).toBe(false);
+  });
+});
+
+describe('pickMostRelevantMessage', () => {
+  test('returns the first message containing a keyword', () => {
+    const msgs = ['no match', 'gas optimization tips', 'another'];
+    expect(pickMostRelevantMessage(msgs)).toBe('gas optimization tips');
+  });
+
+  test('returns null when no messages contain a keyword', () => {
+    const msgs = ['foo', 'bar'];
+    expect(pickMostRelevantMessage(msgs)).toBeNull();
+  });
+
+  test('returns first relevant message when multiple contain keywords', () => {
+    const msgs = ['gas price is high', 'ethereum rocks'];
+    expect(pickMostRelevantMessage(msgs)).toBe('gas price is high');
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest and configure ts-jest
- move keyword utilities into new `relevance.ts`
- use utilities from main bot file
- add tests for `containsRelevantKeyword` and `pickMostRelevantMessage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f40461a68832c9c08fffe4d7ec8c9