### PR TITLE
Add enqueueChannel TypeScript utility

### DIFF
--- a/queue.ts
+++ b/queue.ts
@@ -1,0 +1,18 @@
+export interface RedisSetClient {
+  sismember(key: string, value: string): Promise<number>;
+  sadd(key: string, value: string): Promise<number>;
+}
+
+/**
+ * Enqueue a channel if it hasn't been processed before.
+ * This prevents unnecessary writes when a channel was already handled.
+ */
+export async function enqueueChannel(
+  redis: RedisSetClient,
+  channel: string
+): Promise<void> {
+  const alreadyProcessed = await redis.sismember('processed_channels', channel);
+  if (alreadyProcessed === 0) {
+    await redis.sadd('pending_channels', channel);
+  }
+}

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,0 +1,33 @@
+import { enqueueChannel, RedisSetClient } from '../queue';
+
+class MockRedis implements RedisSetClient {
+  processed = new Set<string>();
+  pending = new Set<string>();
+
+  async sismember(key: string, value: string): Promise<number> {
+    const set = key === 'processed_channels' ? this.processed : this.pending;
+    return set.has(value) ? 1 : 0;
+  }
+
+  async sadd(key: string, value: string): Promise<number> {
+    const set = key === 'processed_channels' ? this.processed : this.pending;
+    const sizeBefore = set.size;
+    set.add(value);
+    return set.size > sizeBefore ? 1 : 0;
+  }
+}
+
+describe('enqueueChannel', () => {
+  test('adds channel to pending when not processed', async () => {
+    const redis = new MockRedis();
+    await enqueueChannel(redis, 'chan1');
+    expect(redis.pending.has('chan1')).toBe(true);
+  });
+
+  test('does not add channel when already processed', async () => {
+    const redis = new MockRedis();
+    redis.processed.add('chan2');
+    await enqueueChannel(redis, 'chan2');
+    expect(redis.pending.has('chan2')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `enqueueChannel` helper for Redis-based queue
- add unit tests for the helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f46c2e588832c9b9d457a6c31bd42