### PR TITLE
Implement discovery routine

### DIFF
--- a/channel_discovery.ts
+++ b/channel_discovery.ts
@@ -1,0 +1,20 @@
+export interface Searcher {
+  searchChannels(keyword: string): Promise<string[]>;
+}
+
+import { enqueueChannel, RedisSetClient } from './queue';
+
+export const RECRUITMENT_KEYWORDS = ['job', 'hiring', 'career'];
+
+export async function discoverChannels(
+  searcher: Searcher,
+  redis: RedisSetClient,
+  keywords: string[] = RECRUITMENT_KEYWORDS,
+): Promise<void> {
+  for (const kw of keywords) {
+    const channels = await searcher.searchChannels(kw);
+    for (const chan of channels) {
+      await enqueueChannel(redis, chan);
+    }
+  }
+}

--- a/tests/channel_discovery.test.ts
+++ b/tests/channel_discovery.test.ts
@@ -1,0 +1,43 @@
+import { discoverChannels, RECRUITMENT_KEYWORDS, Searcher } from '../channel_discovery';
+import { RedisSetClient } from "../queue";
+
+
+class MockSearcher implements Searcher {
+  calls: string[] = [];
+  constructor(private results: Record<string, string[]>) {}
+  async searchChannels(keyword: string): Promise<string[]> {
+    this.calls.push(keyword);
+    return this.results[keyword] || [];
+  }
+}
+
+class MockRedis implements RedisSetClient {
+  processed = new Set<string>();
+  pending = new Set<string>();
+  async sismember(key: string, value: string): Promise<number> {
+    const set = key === 'processed_channels' ? this.processed : this.pending;
+    return set.has(value) ? 1 : 0;
+  }
+  async sadd(key: string, value: string): Promise<number> {
+    const set = key === 'processed_channels' ? this.processed : this.pending;
+    const sizeBefore = set.size;
+    set.add(value);
+    return set.size > sizeBefore ? 1 : 0;
+  }
+}
+
+describe('discoverChannels', () => {
+  test('searches each keyword and enqueues results', async () => {
+    const searcher = new MockSearcher({
+      job: ['chan1'],
+      hiring: ['chan2', 'chan3'],
+      career: [],
+    });
+    const redis = new MockRedis();
+    await discoverChannels(searcher, redis);
+    expect(searcher.calls).toEqual(RECRUITMENT_KEYWORDS);
+    expect(redis.pending.has('chan1')).toBe(true);
+    expect(redis.pending.has('chan2')).toBe(true);
+    expect(redis.pending.has('chan3')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add routine for searching new channels by recruitment keywords
- test that discovery triggers searches and enqueues results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f493b0318832c8e6b15340084e051