### PR TITLE
Implement TGStat/Telegram search

### DIFF
--- a/telegram-search.ts
+++ b/telegram-search.ts
@@ -1,0 +1,27 @@
+import { TelegramClient, Api } from 'telegram';
+
+export async function searchTelegram(
+  client: TelegramClient,
+  keyword: string,
+): Promise<string[]> {
+  try {
+    const res = (await client.invoke(
+      new Api.contacts.Search({
+        q: keyword,
+        limit: 50,
+        hash: Api.BigInteger.fromValue(0),
+      })
+    )) as any;
+    const names: string[] = [];
+    for (const chat of res.chats) {
+      if (chat instanceof Api.Channel && chat.username) {
+        names.push(`@${chat.username}`);
+      }
+    }
+    return names;
+  } catch (err: any) {
+    console.error(`[searchTelegram] Error searching "${keyword}":`, err.message || err);
+    return [];
+  }
+}
+

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,40 @@
+import { searchTGStat } from '../tgstat-search';
+import { searchTelegram } from '../telegram-search';
+import axios from 'axios';
+import { Api } from 'telegram';
+
+jest.mock('axios');
+
+jest.mock('telegram', () => {
+  return {
+    Api: {
+      contacts: {
+        Search: jest.fn(),
+      },
+      Channel: class Channel {
+        constructor(public username: string) {}
+      },
+    },
+  };
+});
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedInvoke = jest.fn();
+
+describe('searchTGStat', () => {
+  test('returns usernames from API', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { response: { items: [{ username: 'chan1' }, { username: 'chan2' }] } } });
+    const res = await searchTGStat('gas');
+    expect(res).toEqual(['@chan1', '@chan2']);
+  });
+});
+
+describe('searchTelegram', () => {
+  test('collects usernames from Telegram search', async () => {
+    mockedInvoke.mockResolvedValue({ chats: [new Api.Channel('foo'), new Api.Channel('bar')] });
+    const client = { invoke: mockedInvoke } as any;
+    const res = await searchTelegram(client, 'foo');
+    expect(mockedInvoke).toHaveBeenCalled();
+    expect(res).toEqual(['@foo', '@bar']);
+  });
+});

--- a/tgstat-search.ts
+++ b/tgstat-search.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+export async function searchTGStat(keyword: string): Promise<string[]> {
+  const token = process.env.TGSTAT_SEARCH_KEY;
+  if (!token) throw new Error('TGSTAT_SEARCH_KEY env var not set');
+
+  const url = `https://api.tgstat.ru/channels/search?token=${token}&q=${encodeURIComponent(keyword)}&limit=50`;
+
+  try {
+    const resp = await axios.get(url, { timeout: 20000 });
+    const items = resp.data?.response?.items ?? [];
+    return items
+      .map((it: any) => it.username ? `@${it.username}` : null)
+      .filter((u: string | null): u is string => !!u);
+  } catch (err: any) {
+    console.error(`[searchTGStat] Error searching ${keyword}:`, err.message || err);
+    return [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- remove old HTML scrapers from `gasguardian-userbot.ts`
- add `searchTGStat` module for TGSTAT API queries
- add `searchTelegram` module and use it in `scrapePublicSources`
- guard `main()` execution during tests
- test TGStat and Telegram search functions

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f530689b4832cb27ca4f927c532eb