### PR TITLE
Fix search error and update keywords

### DIFF
--- a/channel_discovery.ts
+++ b/channel_discovery.ts
@@ -4,7 +4,26 @@ export interface Searcher {
 
 import { enqueueChannel, RedisSetClient } from './queue';
 
-export const RECRUITMENT_KEYWORDS = ['job', 'hiring', 'career'];
+export const RECRUITMENT_KEYWORDS = [
+  // English terms
+  'gas fees',
+  'cheap gas',
+  'gas optimization',
+  'defi',
+  'nft',
+  'airdrop',
+  'layer 2',
+  'l2',
+  // Russian equivalents
+  'газовые комиссии',
+  'дешевый газ',
+  'оптимизация газа',
+  'дефи',
+  'нфт',
+  'эйрдроп',
+  'слой 2',
+  'л2',
+];
 
 export async function discoverChannels(
   searcher: Searcher,

--- a/gasguardian-userbot.ts
+++ b/gasguardian-userbot.ts
@@ -375,7 +375,7 @@ async function fetchRecentMessages(
         maxId: 0,
         minId: 0,
         addOffset: 0,
-        hash: Api.BigInteger.fromValue(0),
+        hash: BigInt(0),
       })
     );
     const msgs = (history as any).messages as Api.Message[];
@@ -412,7 +412,7 @@ async function channelIsActiveAndLarge(username: string): Promise<boolean> {
         maxId: 0,
         minId: 0,
         addOffset: 0,
-        hash: Api.BigInteger.fromValue(0),
+        hash: BigInt(0),
       })
     )) as any;
     const msgs: Api.Message[] = hist.messages || [];
@@ -540,7 +540,7 @@ async function filterByTGStatBot(username: string): Promise<boolean> {
         maxId: 0,
         minId: 0,
         addOffset: 0,
-        hash: Api.BigInteger.fromValue(0),
+        hash: BigInt(0),
       })
     )) as any;
 

--- a/telegram-search.ts
+++ b/telegram-search.ts
@@ -9,7 +9,7 @@ export async function searchTelegram(
       new Api.contacts.Search({
         q: keyword,
         limit: 50,
-        hash: Api.BigInteger.fromValue(0),
+        hash: BigInt(0),
       })
     )) as any;
     const names: string[] = [];

--- a/tests/channel_discovery.test.ts
+++ b/tests/channel_discovery.test.ts
@@ -4,10 +4,9 @@ import { RedisSetClient } from "../queue";
 
 class MockSearcher implements Searcher {
   calls: string[] = [];
-  constructor(private results: Record<string, string[]>) {}
   async searchChannels(keyword: string): Promise<string[]> {
     this.calls.push(keyword);
-    return this.results[keyword] || [];
+    return [`${keyword}_chan`];
   }
 }
 
@@ -28,16 +27,10 @@ class MockRedis implements RedisSetClient {
 
 describe('discoverChannels', () => {
   test('searches each keyword and enqueues results', async () => {
-    const searcher = new MockSearcher({
-      job: ['chan1'],
-      hiring: ['chan2', 'chan3'],
-      career: [],
-    });
+    const searcher = new MockSearcher();
     const redis = new MockRedis();
     await discoverChannels(searcher, redis);
     expect(searcher.calls).toEqual(RECRUITMENT_KEYWORDS);
-    expect(redis.pending.has('chan1')).toBe(true);
-    expect(redis.pending.has('chan2')).toBe(true);
-    expect(redis.pending.has('chan3')).toBe(true);
+    expect(redis.pending.size).toBe(RECRUITMENT_KEYWORDS.length);
   });
 });


### PR DESCRIPTION
## Summary
- update Telegram API calls to use `BigInt(0)`
- refresh recruitment keywords with crypto topics in English and Russian
- revise channel discovery test for new keyword list

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f59559fec832cad41318729f3e886