### PR TITLE
Handle missing channelSearch table

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -3,14 +3,30 @@ import { PrismaClient } from '@prisma/client';
 export const prisma = new PrismaClient();
 
 export async function logChannelSearch(username: string): Promise<void> {
-  await prisma.channelSearch.upsert({
-    where: { username },
-    create: { username },
-    update: { searchedAt: new Date() },
-  });
+  try {
+    await prisma.channelSearch.upsert({
+      where: { username },
+      create: { username },
+      update: { searchedAt: new Date() },
+    });
+  } catch (err: any) {
+    if (err.code === 'P2021' || /does not exist/i.test(err.message)) {
+      console.warn('[DB] channelSearch table missing, skipping log');
+    } else {
+      throw err;
+    }
+  }
 }
 
 export async function channelAlreadySearched(username: string): Promise<boolean> {
-  const existing = await prisma.channelSearch.findUnique({ where: { username } });
-  return !!existing;
+  try {
+    const existing = await prisma.channelSearch.findUnique({ where: { username } });
+    return !!existing;
+  } catch (err: any) {
+    if (err.code === 'P2021' || /does not exist/i.test(err.message)) {
+      console.warn('[DB] channelSearch table missing, assuming not searched');
+      return false;
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary
- handle Prisma error when channelSearch table is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6976dad8832c94458bb2e67d05e8