### PR TITLE
Fix missing channelSearch table

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -1,9 +1,28 @@
 import { PrismaClient } from '@prisma/client';
 
+let channelSearchReady = false;
+
+async function ensureChannelSearchTable(): Promise<void> {
+  if (channelSearchReady) return;
+  try {
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS "channelSearch" (
+        id SERIAL PRIMARY KEY,
+        username TEXT UNIQUE NOT NULL,
+        "searchedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    `);
+    channelSearchReady = true;
+  } catch (err) {
+    console.warn('[DB] failed to ensure channelSearch table', err);
+  }
+}
+
 export const prisma = new PrismaClient();
 
 export async function logChannelSearch(username: string): Promise<void> {
   try {
+    await ensureChannelSearchTable();
     await prisma.channelSearch.upsert({
       where: { username },
       create: { username },
@@ -11,7 +30,13 @@ export async function logChannelSearch(username: string): Promise<void> {
     });
   } catch (err: any) {
     if (err.code === 'P2021' || /does not exist/i.test(err.message)) {
-      console.warn('[DB] channelSearch table missing, skipping log');
+      console.warn('[DB] channelSearch table missing, attempting to create');
+      await ensureChannelSearchTable();
+      await prisma.channelSearch.upsert({
+        where: { username },
+        create: { username },
+        update: { searchedAt: new Date() },
+      });
     } else {
       throw err;
     }
@@ -20,12 +45,15 @@ export async function logChannelSearch(username: string): Promise<void> {
 
 export async function channelAlreadySearched(username: string): Promise<boolean> {
   try {
+    await ensureChannelSearchTable();
     const existing = await prisma.channelSearch.findUnique({ where: { username } });
     return !!existing;
   } catch (err: any) {
     if (err.code === 'P2021' || /does not exist/i.test(err.message)) {
-      console.warn('[DB] channelSearch table missing, assuming not searched');
-      return false;
+      console.warn('[DB] channelSearch table missing, attempting to create');
+      await ensureChannelSearchTable();
+      const existing = await prisma.channelSearch.findUnique({ where: { username } });
+      return !!existing;
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
- auto-create channelSearch table if missing
- retry operations after creation to avoid warnings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d2a5668832cb1c1151a2a36549e