### PR TITLE
Initialize channelSearch table on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# GasGuardian Userbot
+
+This repository contains a Telegram userbot that helps discover recruitment channels and engage with them.
+
+## Database initialization
+
+When the bot starts it must have a table called `channelSearch` available. The `main` function now runs `ensureChannelSearchTable()` right after connecting to Telegram to create this table if needed. Ensure your `.env` points to a reachable database before starting the bot.

--- a/db.ts
+++ b/db.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 
 let channelSearchReady = false;
 
-async function ensureChannelSearchTable(): Promise<void> {
+export async function ensureChannelSearchTable(): Promise<void> {
   if (channelSearchReady) return;
   try {
     await prisma.$executeRawUnsafe(`

--- a/gasguardian-userbot.ts
+++ b/gasguardian-userbot.ts
@@ -17,7 +17,12 @@ import OpenAI from "openai";
 import { searchTGStat } from "./tgstat-search";
 import { searchTelegram } from "./telegram-search";
 import Redis from "ioredis";
-import { prisma, logChannelSearch, channelAlreadySearched } from "./db";
+import {
+  prisma,
+  logChannelSearch,
+  channelAlreadySearched,
+  ensureChannelSearchTable,
+} from "./db";
 import schedule from "node-schedule";
 import {
   RELEVANT_KEYWORDS,
@@ -1185,6 +1190,8 @@ async function main() {
     phoneCode: async () => "",
     onError: (err) => console.error("[TG] Client error:", err),
   });
+
+  await ensureChannelSearchTable();
 
   console.log("[BOT] Client started, registering event handler");
   client.addEventHandler(handleMessage, new NewMessage({}));


### PR DESCRIPTION
## Summary
- create README with brief initialization notes
- export `ensureChannelSearchTable` from db utilities
- call `ensureChannelSearchTable` when starting the bot

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f72243d90832caf68f746dddb440b