### PR TITLE
Add dynamic keyword helper

### DIFF
--- a/channel_discovery.ts
+++ b/channel_discovery.ts
@@ -3,6 +3,7 @@ export interface Searcher {
 }
 
 import { enqueueChannel, RedisSetClient } from './queue';
+import { getDynamicKeywords } from './keyword-helper';
 
 export const RECRUITMENT_KEYWORDS = [
   // English terms
@@ -30,7 +31,9 @@ export async function discoverChannels(
   redis: RedisSetClient,
   keywords: string[] = RECRUITMENT_KEYWORDS,
 ): Promise<void> {
-  for (const kw of keywords) {
+  const dynamic = await getDynamicKeywords();
+  const allKeywords = Array.from(new Set([...keywords, ...dynamic]));
+  for (const kw of allKeywords) {
     const channels = await searcher.searchChannels(kw);
     for (const chan of channels) {
       await enqueueChannel(redis, chan);

--- a/gasguardian-userbot.ts
+++ b/gasguardian-userbot.ts
@@ -25,6 +25,7 @@ import {
   pickMostRelevantMessage,
 } from "./relevance";
 import { RECRUITMENT_KEYWORDS } from "./channel_discovery";
+import { getDynamicKeywords } from "./keyword-helper";
 
 // ----------------------------------------
 // === ENVIRONMENT & CONFIGURATION  ======
@@ -572,8 +573,10 @@ async function filterByTGStatBot(username: string): Promise<boolean> {
  */
 async function scrapePublicSources(maxCandidates: number): Promise<string[]> {
   const usernamesSet = new Set<string>();
+  const dynamic = await getDynamicKeywords();
+  const keywords = Array.from(new Set([...RECRUITMENT_KEYWORDS, ...dynamic]));
 
-  for (const kw of RECRUITMENT_KEYWORDS) {
+  for (const kw of keywords) {
     const [tgstat, telegram] = await Promise.all([
       searchTGStat(kw),
       searchTelegram(client, kw),

--- a/keyword-helper.ts
+++ b/keyword-helper.ts
@@ -1,0 +1,36 @@
+import { fetchCryptoPanicNews } from './external-data';
+
+let cachedKeywords: string[] = [];
+let lastFetched = 0;
+
+export function __resetDynamicCache() {
+  cachedKeywords = [];
+  lastFetched = 0;
+}
+
+export async function getDynamicKeywords(): Promise<string[]> {
+  const refreshMin = Number(process.env.DYNAMIC_KEYWORD_REFRESH_MINUTES || '60');
+  const now = Date.now();
+  if (cachedKeywords.length > 0 && now - lastFetched < refreshMin * 60_000) {
+    return cachedKeywords;
+  }
+
+  try {
+    const data = await fetchCryptoPanicNews();
+    const set = new Set<string>();
+    for (const item of data?.results ?? []) {
+      const currencies = (item as any).currencies ?? [];
+      for (const cur of currencies) {
+        if (cur && typeof cur.code === 'string') {
+          set.add(cur.code.toLowerCase());
+        }
+      }
+    }
+    cachedKeywords = Array.from(set);
+    lastFetched = now;
+    return cachedKeywords;
+  } catch (err: any) {
+    console.error('[getDynamicKeywords] Failed to fetch:', err.message || err);
+    return cachedKeywords;
+  }
+}

--- a/tests/keyword-helper.test.ts
+++ b/tests/keyword-helper.test.ts
@@ -1,0 +1,44 @@
+import { getDynamicKeywords, __resetDynamicCache } from '../keyword-helper';
+import { fetchCryptoPanicNews } from '../external-data';
+
+jest.mock('../external-data');
+
+const mockedFetch = fetchCryptoPanicNews as jest.MockedFunction<typeof fetchCryptoPanicNews>;
+
+beforeEach(() => {
+  __resetDynamicCache();
+  jest.spyOn(Date, 'now').mockReturnValue(0);
+  mockedFetch.mockResolvedValue({
+    results: [
+      { currencies: [{ code: 'ETH' }, { code: 'BTC' }] },
+      { currencies: [{ code: 'ETH' }, { code: 'MATIC' }] },
+    ],
+  } as any);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.resetAllMocks();
+});
+
+test('collects unique currency codes from news', async () => {
+  const res = await getDynamicKeywords();
+  expect(res).toEqual(['eth', 'btc', 'matic']);
+});
+
+test('uses cached keywords within refresh window', async () => {
+  await getDynamicKeywords();
+  mockedFetch.mockResolvedValue({ results: [{ currencies: [{ code: 'SOL' }] }] } as any);
+  const res = await getDynamicKeywords();
+  expect(res).toEqual(['eth', 'btc', 'matic']);
+  expect(mockedFetch).toHaveBeenCalledTimes(1);
+});
+
+test('refreshes after refresh window', async () => {
+  await getDynamicKeywords();
+  mockedFetch.mockResolvedValue({ results: [{ currencies: [{ code: 'SOL' }] }] } as any);
+  (Date.now as jest.Mock).mockReturnValue(1000 * 60 * 61);
+  const res = await getDynamicKeywords();
+  expect(res).toEqual(['sol']);
+  expect(mockedFetch).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Summary
- derive dynamic keywords from CryptoPanic
- merge dynamic keywords into `discoverChannels`
- merge dynamic keywords into `scrapePublicSources`
- expose `DYNAMIC_KEYWORD_REFRESH_MINUTES` env var
- test keyword generation logic

## Testing
- `npx jest` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f724888d0832c980fc3acc8788e59