### PR TITLE
Centralize env helper

### DIFF
--- a/env-helper.ts
+++ b/env-helper.ts
@@ -1,0 +1,10 @@
+export function getEnv(name: string, required = true): string {
+  const realKey = Object.keys(process.env).find((k) =>
+    k.trim().replace(/^\uFEFF/, "") === name
+  );
+  const value = realKey ? process.env[realKey] : undefined;
+  if (required && (!value || value.trim() === "")) {
+    throw new Error(`[GasGuardian] Missing required env var → ${name}`);
+  }
+  return value ? value.trim() : "";
+}

--- a/external-data.ts
+++ b/external-data.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
+import { getEnv } from './env-helper';
 
 export async function fetchBlocknativeGas() {
-  const key = process.env.BLOCKNATIVE_KEY;
+  const key = getEnv('BLOCKNATIVE_KEY');
   if (!key) throw new Error('BLOCKNATIVE_KEY not set');
   const resp = await axios.get('https://api.blocknative.com/gasprices/blockprices', {
     headers: { Authorization: key },
@@ -11,7 +12,7 @@ export async function fetchBlocknativeGas() {
 }
 
 export async function fetchCryptoPanicNews() {
-  const key = process.env.CRYPTOPANIC_KEY;
+  const key = getEnv('CRYPTOPANIC_KEY');
   if (!key) throw new Error('CRYPTOPANIC_KEY not set');
   const url = `https://cryptopanic.com/api/v1/posts/?auth_token=${key}&kind=news`;
   const resp = await axios.get(url, { timeout: 10000 });
@@ -19,7 +20,7 @@ export async function fetchCryptoPanicNews() {
 }
 
 export async function fetchDappRadarTop() {
-  const key = process.env.DAPPRADAR_KEY;
+  const key = getEnv('DAPPRADAR_KEY');
   if (!key) throw new Error('DAPPRADAR_KEY not set');
   const resp = await axios.get('https://api.dappradar.com/4/dapps', {
     headers: { 'X-BLOBR-KEY': key },
@@ -29,7 +30,7 @@ export async function fetchDappRadarTop() {
 }
 
 export async function fetchCoinglassOI() {
-  const key = process.env.COINGLASS_KEY;
+  const key = getEnv('COINGLASS_KEY');
   if (!key) throw new Error('COINGLASS_KEY not set');
   const resp = await axios.get('https://open-api.coinglass.com/api/pro/v1/futures/openInterest', {
     headers: { coinglassSecret: key },
@@ -39,7 +40,7 @@ export async function fetchCoinglassOI() {
 }
 
 export async function queryBitquery(query: string, variables: any = {}) {
-  const key = process.env.BITQUERY_KEY;
+  const key = getEnv('BITQUERY_KEY');
   if (!key) throw new Error('BITQUERY_KEY not set');
   const resp = await axios.post(
     'https://streaming.bitquery.io/graphql',

--- a/gasguardian-userbot.ts
+++ b/gasguardian-userbot.ts
@@ -31,21 +31,12 @@ import {
 } from "./relevance";
 import { RECRUITMENT_KEYWORDS } from "./channel_discovery";
 import { getDynamicKeywords } from "./keyword-helper";
+import { getEnv } from "./env-helper";
 
 // ----------------------------------------
 // === ENVIRONMENT & CONFIGURATION  ======
 // ----------------------------------------
 
-function getEnv(name: string, required = true): string {
-  const realKey = Object.keys(process.env).find((k) =>
-    k.trim().replace(/^\uFEFF/, "") === name
-  );
-  const value = realKey ? process.env[realKey] : undefined;
-  if (required && (!value || value.trim() === "")) {
-    throw new Error(`[GasGuardian] Missing required env var → ${name}`);
-  }
-  return value ? value.trim() : "";
-}
 
 const env = {
   TG_API_ID: Number(getEnv("TG_API_ID")),


### PR DESCRIPTION
## Summary
- add `env-helper` for trimming BOM issues
- use `getEnv` in `gasguardian-userbot` and `external-data`

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f7589c13c832c9beb6775f909ca55