### PR TITLE
Fix dotenv loading path

### DIFF
--- a/gasguardian-userbot.ts
+++ b/gasguardian-userbot.ts
@@ -7,8 +7,10 @@
 // Updated: 06/05/2025 (using gpt-4o)
 
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { config as dotenvConfig } from "dotenv";
-dotenvConfig({ path: path.resolve(process.cwd(), ".env") });
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenvConfig({ path: path.resolve(__dirname, ".env") });
 
 import { TelegramClient, Api } from "telegram";
 import { StringSession } from "telegram/sessions";


### PR DESCRIPTION
## Summary
- ensure dotenv config resolves from script directory

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f78f4972c832c87630196625d7774