### PR TITLE
Improve dynamic keyword sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository contains a Telegram userbot that helps discover recruitment chan
 ## Database initialization
 
 When the bot starts it must have a table called `channelSearch` available. The `main` function now runs `ensureChannelSearchTable()` right after connecting to Telegram to create this table if needed. Ensure your `.env` points to a reachable database before starting the bot.
+
+## Dynamic keyword discovery
+
+Channel discovery combines a static set of recruitment phrases with trending cryptocurrency tickers. The tickers are pulled from CryptoPanic news and DappRadar's top dapps list. Results from both sources are cached for one hour by default, minimizing API usage while keeping the keywords fresh.


### PR DESCRIPTION
## Summary
- expand dynamic keywords by adding DappRadar top dapps
- document how dynamic keywords are gathered
- test new combined keyword logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7b672644832ca71fee42d8f7c55b